### PR TITLE
Deleted "using UnityEditor;"

### DIFF
--- a/GlitchEffect.cs
+++ b/GlitchEffect.cs
@@ -10,7 +10,6 @@ to make commercial use of the work
 */
 
 using UnityEngine;
-using UnityEditor;
 
 [ExecuteInEditMode]
 [AddComponentMenu("Image Effects/GlitchEffect")]


### PR DESCRIPTION
The UnityEditor namespace is not available in builds. It will build without the namespace.
